### PR TITLE
Added public Parse method that takes StreamReader

### DIFF
--- a/src/SharpCastXml/Parser/CppParser.cs
+++ b/src/SharpCastXml/Parser/CppParser.cs
@@ -173,6 +173,16 @@ namespace SharpCastXml.Parser
         
         public Dictionary<string, int> IncludeMacroCounts { get; } = new Dictionary<string, int>();
 
+        /// <summary>
+        /// Parses the xml file specified by StreamReader.
+        /// </summary>
+        /// <param name="reader">StreamReader for xml file</param>
+        /// <param name="groupSkeleton">CppModule</param>
+        public void Parse(StreamReader reader, CppModule groupSkeleton)
+        {
+            _group = groupSkeleton;
+            Parse(reader);
+        }
 
         /// <summary>
         /// Parses the specified reader.


### PR DESCRIPTION
This way it is possible to parse gcc.xml that was created manually (for example because castxml.exe must be started with Visual Studio developer variables and paths).