### PR TITLE
Fix: fundamental type "long long" naming and .NET 10 .Reverse() ambig…

### DIFF
--- a/src/SharpCastXml/CppModel/CppElement.cs
+++ b/src/SharpCastXml/CppModel/CppElement.cs
@@ -220,7 +220,7 @@ namespace SharpCastXml.CppModel
                 return;
             }
 
-            Attributes = attributes.Split(' ').Reverse().ToArray();
+            Attributes = attributes.Split(' ').AsEnumerable().Reverse().ToArray();
             
             
 

--- a/src/SharpCastXml/Parser/CppParser.cs
+++ b/src/SharpCastXml/Parser/CppParser.cs
@@ -375,7 +375,7 @@ namespace SharpCastXml.Parser
 
             // Clang outputs attributes in reverse order
             // TODO: Check if applies to all declarations
-            foreach (var item in attributes.Split(' ').Reverse())
+            foreach (var item in attributes.Split(' ').AsEnumerable().Reverse())
             {
                 var newItem = item;
                 if (newItem.StartsWith(gccXmlAttribute))
@@ -1296,7 +1296,7 @@ namespace SharpCastXml.Parser
             if (longCount == 1 && outputType == "double")
                 outputType = "long double";     // 96 bytes, unhandled
             if (longCount == 2)
-                outputType = "longlong";
+                outputType = "long long";
             if (shortCount == 1)
                 outputType = "short";
             if (isUnsigned)


### PR DESCRIPTION
…uity

ParseFundamentalType emitted "longlong" (no space) for CastXML's "long long int" / "long long unsigned int", producing invalid C++ type names like `unsigned longlong` in generated bindings. Emit "long long".

Also fix a .NET 10 SDK build break: `string[].Reverse()` now binds to MemoryExtensions.Reverse<T>(Span<T>) (in-place, returns void) instead of Enumerable.Reverse, because arrays convert to Span<T>. Disambiguate to the LINQ overload with .AsEnumerable().Reverse() in CppParser and CppElement.